### PR TITLE
Add support for displaying the ISA string on RISC-V CPUs

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2499,6 +2499,18 @@ get_cpu() {
                     [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' "$cpu_file")"
                 ;;
 
+                "riscv"* | "rv"*)
+                    cpu_uarch="$(awk -F':' '/uarch/ {print $2; exit}' "$cpu_file")"
+                    # RISC-V ISA string example: "rv64imafdch_zicsr_zifencei".
+                    cpu_isa="$(awk -F':' '/isa/ {print $2; exit}' "$cpu_file")"
+                    # The _z parts are not important for CPU showcasing, so we remove them.
+                    cpu_isa="${cpu_isa%%_*}"
+                    # Then we replace "imafd" with "g" since "g" is a shorthand.
+                    cpu_isa="${cpu_isa/imafd/g}"
+                    # The final ISA output of the above example is "rv64gch".
+                    cpu="$cpu_uarch $cpu_isa"
+                ;;
+
                 "arm"* | "aarch64")
                     if [[ $(trim "$distro") == Android* ]]; then
                         # Android roms have modified cpuinfo that shows CPU model as a string


### PR DESCRIPTION
This PR adds support for displaying the ISA string (like "rv64gc") in the CPU section on RISC-V CPUs.

I have tested this both on real hardware (Debian on StarFive VisionFive 2) and an emulator (Ubuntu on Qemu).

Example output on real hardware (Debian on StarFive VisionFive 2):

```
$ ./neofetch 
       _,met$$$$$gg.             user@starfive 
    ,g$$$$$$$$$$$$$$$P.          ------------- 
  ,g$$P"        """Y$$.".        OS: Debian GNU/Linux bookworm/sid riscv64 
 ,$$P'              `$$$.        Host: StarFive VisionFive V2 
',$$P       ,ggs.     `$$b:      Kernel: 5.15.0-starfive 
`d$$'     ,$P"'   .    $$$       Uptime: 2 mins 
 $$P      d$'     ,    $$P       Packages: 1888 (dpkg) 
 $$:      $$.   -    ,d$$'       Shell: bash 5.1.16 
 $$;      Y$b._   _,d$P'         Resolution: 3840x2160 
 Y$$.    `.`"Y$$$$P"'            Terminal: /dev/pts/0 
 `$$b      "-.__                 CPU: sifive,u74-mc rv64gc (4) @ 1.500GHz 
  `Y$$                           Memory: 399 MiB / 7927 MiB 
   `Y$$.                         Network: 100 Mbps 
     `$$b.
       `Y$$b.                                            
          `"Y$b._                                        
              `"""
```

Example output on the emulator (Ubuntu 20.04 on Qemu):

```
$ ./neofetch 
                             ....             ubuntu@ubuntu 
              .',:clooo:  .:looooo:.          ------------- 
           .;looooooooc  .oooooooooo'         OS: Ubuntu 20.04.2 LTS riscv64 
        .;looooool:,''.  :ooooooooooc         Host: riscv-virtio,qemu 
       ;looool;.         'oooooooooo,         Kernel: 5.8.0-14-generic 
      ;clool'             .cooooooc.  ,,      Uptime: 3 hours, 45 mins 
         ...                ......  .:oo,     Packages: 760 (dpkg) 
  .;clol:,.                        .loooo'    Shell: bash 5.0.17 
 :ooooooooo,                        'ooool    Terminal: /dev/pts/0 
'ooooooooooo.                        loooo.   CPU: rv64gch (8) 
'ooooooooool                         coooo.   Memory: 341 MiB / 16000 MiB 
 ,loooooooc.                        .loooo.   Network: Unknown 
   .,;;;'.                          ;ooooc
       ...                         ,ooool.                            
    .cooooc.              ..',,'.  .cooo.                             
      ;ooooo:.           ;oooooooc.  :l.
       .coooooc,..      coooooooooo.
         .:ooooooolc:. .ooooooooooo'
           .':loooooo;  ,oooooooooc
               ..';::c'  .;loooo:'
                             .
```

For comparison, here is what the output looks like in unifetch before this PR:

<details>
Old/existing output on real hardware (Debian on StarFive VisionFive 2):

```
$ ./neofetch 
       _,met$$$$$gg.             user@starfive 
    ,g$$$$$$$$$$$$$$$P.          ------------- 
  ,g$$P"        """Y$$.".        OS: Debian GNU/Linux bookworm/sid riscv64 
 ,$$P'              `$$$.        Host: StarFive VisionFive V2 
',$$P       ,ggs.     `$$b:      Kernel: 5.15.0-starfive 
`d$$'     ,$P"'   .    $$$       Uptime: 2 mins 
 $$P      d$'     ,    $$P       Packages: 1888 (dpkg) 
 $$:      $$.   -    ,d$$'       Shell: bash 5.1.16 
 $$;      Y$b._   _,d$P'         Resolution: 3840x2160 
 Y$$.    `.`"Y$$$$P"'            Terminal: /dev/pts/0 
 `$$b      "-.__                 CPU: sifive,u74-mc (4) @ 1.500GHz 
  `Y$$                           Memory: 399 MiB / 7927 MiB 
   `Y$$.                         Network: 100 Mbps 
     `$$b.
       `Y$$b.                                            
          `"Y$b._                                        
              `"""
```

Old/existing output on the emulator (Ubuntu 20.04 on Qemu):

```
$ ./neofetch 
                             ....             ubuntu@ubuntu 
              .',:clooo:  .:looooo:.          ------------- 
           .;looooooooc  .oooooooooo'         OS: Ubuntu 20.04.2 LTS riscv64 
        .;looooool:,''.  :ooooooooooc         Host: riscv-virtio,qemu 
       ;looool;.         'oooooooooo,         Kernel: 5.8.0-14-generic 
      ;clool'             .cooooooc.  ,,      Uptime: 3 hours, 47 mins 
         ...                ......  .:oo,     Packages: 760 (dpkg) 
  .;clol:,.                        .loooo'    Shell: bash 5.0.17 
 :ooooooooo,                        'ooool    Terminal: /dev/pts/0 
'ooooooooooo.                        loooo.   CPU: (8) 
'ooooooooool                         coooo.   Memory: 341 MiB / 16000 MiB 
 ,loooooooc.                        .loooo.   Network: Unknown 
   .,;;;'.                          ;ooooc
       ...                         ,ooool.                            
    .cooooc.              ..',,'.  .cooo.                             
      ;ooooo:.           ;oooooooc.  :l.
       .coooooc,..      coooooooooo.
         .:ooooooolc:. .ooooooooooo'
           .':loooooo;  ,oooooooooc
               ..';::c'  .;loooo:'
                             .
```
</details>

